### PR TITLE
Use ClusterId for CLOUDABILITY_CLUSTER_NAME

### DIFF
--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -133,6 +133,8 @@ spec:
             {{- end }}
 
             {{- if .Values.agent.cloudability.enabled }}
+            - name: CLOUDABILITY_CLUSTER_NAME
+              value: {{ .Values.clusterId | quote }}
             - name: CLOUDABILITY_EMITTER_ENABLED
               value: "true"
             - name: CLOUDABILITY_SCRATCH_DIR


### PR DESCRIPTION
The env is needed for cldy to stitch costs to a cluster name