### PR TITLE
Update Helm Chart to Mount Cloudability Secrets as Volume

### DIFF
--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -199,6 +199,22 @@ spec:
             - name: CLOUDABILITY_CUSTOM_AZURE_BLOB_CLIENT_ID
               value: {{ .Values.agent.cloudability.customAzureClientID | quote }}
             {{- end }}
+            {{- if .Values.agent.cloudability.keyAccessFile }}
+            - name: CLOUDABILITY_KEY_ACCESS_FILEPATH
+              value: "{{ .Values.agent.cloudability.pathToCloudabilitySecrets -}}/{{ .Values.agent.cloudability.keyAccessFile }}"
+            {{- end }}
+            {{- if .Values.agent.cloudability.keySecretFile }}
+            - name: CLOUDABILITY_KEY_SECRET_FILEPATH
+              value: "{{ .Values.agent.cloudability.pathToCloudabilitySecrets -}}/{{ .Values.agent.cloudability.keySecretFile }}"
+            {{- end }}
+            {{- if .Values.agent.cloudability.envIDFile }}
+            - name: CLOUDABILITY_ENV_ID_FILEPATH
+              value: "{{ .Values.agent.cloudability.pathToCloudabilitySecrets -}}/{{ .Values.agent.cloudability.envIDFile }}"
+            {{- end }}
+            {{- if .Values.agent.cloudability.customAzureBlobClientSecretFile }}
+            - name: CLOUDABILITY_CUSTOM_AZURE_BLOB_CLIENT_SECRET_FILEPATH
+              value: "{{ .Values.agent.cloudability.pathToCloudabilitySecrets -}}/{{ .Values.agent.cloudability.customAzureBlobClientSecretFile }}"
+            {{- end }}
 
             - name: KUBECOST_EMITTER_ENABLED
               value:  {{ .Values.agent.kubecost.enabled | quote }}
@@ -212,7 +228,7 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" .) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.agent.cloudability.enabled}}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
@@ -221,10 +237,6 @@ spec:
             {{- if .Values.extraEnvVarsSecret }}
             - secretRef:
                 name: {{ .Values.extraEnvVarsSecret }}
-            {{- end }}
-            {{- if .Values.agent.cloudability.enabled }}
-            - secretRef:
-                name: {{ include "cloudability.secret.name" . | trim }}
             {{- end }}
           {{- end }}
           ports:
@@ -275,6 +287,10 @@ spec:
               subPath: federated-store.yaml
               readOnly: true
             {{- end }}
+            {{- if .Values.agent.cloudability.enabled }}
+            - name: cloudability-secret-store
+              mountPath: {{ .Values.agent.cloudability.pathToCloudabilitySecrets}}
+            {{- end }}
      
            
             {{- if .Values.persistence.enabled }}
@@ -302,7 +318,18 @@ spec:
             secretName: {{ .Values.exportBucket.secret.existingSecret }}
             defaultMode: 256
         {{- end }}
-        
+        {{ if .Values.agent.cloudability.secret.create}}
+        - name: cloudability-secret-store
+          secret:
+            secretName: {{ include "cloudability.secret.name" . | trim }}
+            defaultMode: 256
+        {{- else if (not (empty .Values.agent.cloudability.secret.existingSecret))}}
+        - name: cloudability-secret-store
+          secret:
+            secretName: {{ .Values.agent.cloudability.secret.existingSecret }}
+            defaultMode: 256
+        {{- end }}
+
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" .) | nindent 8 }}
         {{- end }}

--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -127,6 +127,10 @@ exportBucket:
 ## @param agent.exporter.emissionInterval A duration string of how often the core agent exporter will emit new data snapshots to the enabled emitters.
 ## @param agent.cloudability.enabled Enable the cloudability data source
 ## @param agent.kubecost.enabled Enable the kubecost data source
+## @param agent.cloudability.pathToCloudabilitySecrets the path to the location on the filesystem the cloudability secrets are stored
+## @param agent.cloudability.keyAccessFile the name of the keyAccessFile
+## @param agent.cloudability.keySecretFile the name of the keySecretFile
+## @param agent.cloudability.envIDFile the name of the envIDFile
 ## @param agent.cloudability.localWorkingDir The local working directory for the cloudability data source
 ## @param agent.cloudability.uploadRegion The upload region for the cloudability data source
 ## @param agent.cloudability.httpsClientTimeout Amount (in seconds) of time the http client has before timing out requests. Might need to be increased to clusters with large payloads.
@@ -142,6 +146,7 @@ exportBucket:
 ## @param agent.cloudability.customAzureBlobURL Azure blob url for custom uploading agent
 ## @param agent.cloudability.customAzureTenantID Azure tenantID for custom uploading agent
 ## @param agent.cloudability.customAzureClientID Azure clientID for custom uploading agent
+## @param agent.cloudability.customAzureBlobClientSecretFile the name of the customAzureBlobClientSecretFile
 ## @param agent.cloudability.secret.existingSecret The name of an existing secret to use for the cloudability data source. Note, you cannot set both `create` and `existingSecret`.
 ## @param agent.cloudability.secret.create Create a secret for the cloudability data source. cannot be used with existingSecret
 ## @param agent.cloudability.secret.cloudabilityAccessKey The cloudability access key for the cloudability data source
@@ -162,6 +167,10 @@ agent:
     enabled: true
   cloudability:
     enabled: true
+    pathToCloudabilitySecrets: "/etc/secrets"
+    keyAccessFile: "CLOUDABILITY_KEY_ACCESS"
+    keySecretFile: "CLOUDABILITY_KEY_SECRET"
+    envIDFile: "CLOUDABILITY_ENV_ID"
     localWorkingDir: /tmp
     uploadRegion: us
     httpsClientTimeout: 60
@@ -176,6 +185,7 @@ agent:
     customAzureBlobURL: ""
     customAzureTenantID: ""
     customAzureClientID: ""
+    customAzureBlobClientSecretFile: "CLOUDABILITY_CUSTOM_AZURE_BLOB_CLIENT_SECRET"
     emissionInterval: 3m
 
     secret:


### PR DESCRIPTION
This change updates cloudability secrets to be mounted as volumes instead of using them as environment variables backed by a secretRef.

These changes must be released in tandem with https://github.com/kubecost/ibm-finops-agent/pull/53. And this helm chart to agent version (once released is not planned to be backwards compatible as it is released before beta program starts)