### PR TITLE
Add nodes/proxy Permission

### DIFF
--- a/charts/finops-agent/templates/rbac.yaml
+++ b/charts/finops-agent/templates/rbac.yaml
@@ -50,7 +50,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" (dict "value" $annotations "context" .) | nindent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["namespaces", "nodes", "pods", "services", "persistentvolumeclaims", "persistentvolumes", "replicationcontrollers", "nodes/metrics", "nodes/stats"]
+    resources: ["namespaces", "nodes", "pods", "services", "persistentvolumeclaims", "persistentvolumes", "replicationcontrollers", "nodes/metrics", "nodes/stats", "nodes/proxy"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]


### PR DESCRIPTION
The unified agent needs permission to nodes/proxy in order to connect to the node through kubeproxy.

Openshift requires this type of connection and other production Kubernetes clusters may also require this.