### PR TITLE
move gcpKey to a secret

### DIFF
--- a/charts/finops-agent/README.md
+++ b/charts/finops-agent/README.md
@@ -150,8 +150,13 @@ A default `StorageClass` is needed in the Kubernetes cluster to dynamically prov
 | `image.pullPolicy` | IBM FinOps Agent image pull policy | `IfNotPresent` |
 | `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` |
 | `image.debug` | Specify if debug logs should be enabled | `false` |
-| `gcpKey` | GCP API key if deploying to GCP. This can be read only permissions, this is used to fetch current pricing of resources | `""` |
+| `cspPricingApiKey.create` | Note: only used for GCP at this time. Create a secret for the GCP API key. Cannot be used with `existingSecret` | `false` |
+| `cspPricingApiKey.existingSecret` | The name of an existing secret to use for the GCP API key. Note, you cannot set both `create` and `existingSecret` | `""` |
+| `cspPricingApiKey.apiKey` | The GCP API key value. Only used when `create` is true | `""` |
+| `cspPricingApiKey.secretName` | The name of the secret to use for the GCP API key. Only used when `create` is true | `""` |
 | `logLevel` | The log level for the finops agent | `info` |
+
+**Note:** When using an existing/self-managed cspPricingApiKey secret, it must contain a key named `CSP_PRICING_API_KEY`.
 
 ### Federated Storage Configuration
 

--- a/charts/finops-agent/templates/csp-api-key-secret.yaml
+++ b/charts/finops-agent/templates/csp-api-key-secret.yaml
@@ -1,0 +1,32 @@
+{{- /*
+Copyright IBM, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and (not (empty .Values.cspPricingApiKey.existingSecret)) .Values.cspPricingApiKey.create }}
+{{- fail "Cannot set both cspPricingApiKey.existingSecret and cspPricingApiKey.create" }}
+{{- end }}
+
+{{- if .Values.cspPricingApiKey.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.cspPricingApiKey.secretName | trim }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" .) | nindent 4 }}
+    app.kubernetes.io/part-of: finops-agent
+    app.kubernetes.io/component: config
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" .) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{- if .Values.gcpKey }}
+  {{- /*
+  gcpKey is for the old key, remove for GA release.
+  */}}
+  CSP_PRICING_API_KEY: {{ .Values.gcpKey | b64enc | quote }}
+  {{- else }}
+  CSP_PRICING_API_KEY: {{ .Values.cspPricingApiKey.apiKey | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -129,9 +129,12 @@ spec:
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
 
-            {{- if ne (.Values.gcpKey | trim | len) 0 }}
+            {{- if .Values.cspPricingApiKey.apiKey }}
             - name: CLOUD_PROVIDER_API_KEY
-              value: {{ .Values.gcpKey | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cspPricingApiKey.secretName | trim }}
+                  key: CSP_PRICING_API_KEY
             {{- end }}
 
             {{- if .Values.agent.exporter.emissionInterval }}
@@ -286,6 +289,11 @@ spec:
             - name: cloudability-secret-store
               mountPath: {{ .Values.agent.cloudability.pathToCloudabilitySecrets}}
             {{- end }}
+            {{- if or .Values.cspPricingApiKey.create (not (empty .Values.cspPricingApiKey.existingSecret)) }}
+            - name: csp-pricing-api-key-secret
+              mountPath: /opt/gcp
+              readOnly: true
+            {{- end }}
             {{- if .Values.persistence.enabled }}
             - mountPath: {{ .Values.persistence.mountPath }}              
               name: data
@@ -314,6 +322,12 @@ spec:
         - name: cloudability-secret-store
           secret:
             secretName: {{ .Values.agent.cloudability.secret.existingSecret }}
+            defaultMode: 256
+        {{- end }}
+        {{- if .Values.cspPricingApiKey.create}}
+        - name: csp-pricing-api-key-secret
+          secret:
+            secretName: {{ .Values.cspPricingApiKey.secretName | trim }}
             defaultMode: 256
         {{- end }}
         {{- if .Values.extraVolumes }}

--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" .) | nindent 12 }}
           {{- end }}
-        
+
           {{- if .Values.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" .) | nindent 12 }}
           {{- end }}
@@ -94,7 +94,7 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" .) | nindent 12 }}
           {{- end }}
           env:
-            # TODO 
+            # TODO
             {{- with .Values.agent.collectorDataSource }}
             {{- if .enabled }}
             - name: COLLECTOR_DATA_SOURCE_ENABLED
@@ -295,7 +295,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.persistence.enabled }}
-            - mountPath: {{ .Values.persistence.mountPath }}              
+            - mountPath: {{ .Values.persistence.mountPath }}
               name: data
             {{- end }}
           {{- if .Values.extraVolumeMounts }}

--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -97,8 +97,18 @@ image:
   debug: false
 ## If set, this will override the image name and tag.
 fullImageName: ""
-## @param gcpKey GCP API key if deploying to GCP. This can be read only permissions, this is used to fetch current pricing of resources
-gcpKey: ""
+## gcpKey is for the old key, use cspPricingApiKey instead.
+gcpKey: ""  # TODO: remove for GA release
+## @param cspPricingApiKey GCP API key if deploying to GCP. This can be read only permissions, this is used to fetch current pricing of resources
+## @param cspPricingApiKey.existingSecret The name of an existing secret to use for the GCP API key. Note, you cannot set both `create` and `existingSecret`.
+## @param cspPricingApiKey.create Create a secret for the GCP API key. Cannot be used with existingSecret
+## @param cspPricingApiKey.value The GCP API key value. Only used when `create` is true.
+## This is currently only used for GCP.
+cspPricingApiKey:
+  provider: "gcp"
+  secretName: "csp-pricing-api-key"
+  create: true
+  apiKey: ""
 
 ## @param logLevel The log level for the finops agent
 logLevel: "info"


### PR DESCRIPTION
This makes the secret a bit more generic for future CSP pricing API keys and moves the value to a secret per best practices.