### PR TITLE
make /var/configs writable

### DIFF
--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -301,6 +301,9 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /var/configs
+              subPath: configs-dir
             {{- if include "finops-agent.kubecostEnabled" . }}
             - name: federated-storage-config
               mountPath: /var/configs/federated-store.yaml
@@ -328,6 +331,8 @@ spec:
         {{- end }}
       volumes:
         - name: empty-dir
+          emptyDir: {}
+        - name: var-configs-empty-dir
           emptyDir: {}
         {{- if include "finops-agent.kubecostEnabled" . }}
         - name: federated-storage-config


### PR DESCRIPTION
make /var/configs writable
fixes:

```sh
ERR Error opening config: writing /var/configs/gcp.json: opening /var/configs/gcp.json: open /var/configs/gcp.json: read-only file system
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x388 pc=0x2d70c63]

goroutine 9150 [running]:
github.com/opencost/opencost/pkg/cloud/gcp.(*GCP).ClusterInfo(0xc00452f500)
        /app/opencost/pkg/cloud/gcp/provider.go:307 +0x143
github.com/opencost/opencost/pkg/costmodel.(*localClusterInfoProvider).GetClusterInfo(0xc0057a71c0)
        /app/opencost/pkg/costmodel/clusterinfo.go:45 +0x28
github.com/opencost/opencost/pkg/costmodel.ClusterInfoCollector.Collect({{0x47f6420, 0xc0057a71c0}, {{0x0, 0x0, 0x0}, 0x0, 0x0}}, 0xc005416000)
        /app/opencost/pkg/costmodel/metrics.go:57 +0x1a8
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
        /root/go/pkg/mod/github.com/prometheus/client_golang@v1.22.0/prometheus/registry.go:456 +0x105
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather in goroutine 10680
        /root/go/pkg/mod/github.com/prometheus/client_golang@v1.22.0/prometheus/registry.go:548 +0xbf1

```