### PR TITLE
fix cloudy env vars

### DIFF
--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -225,9 +225,9 @@ spec:
               value: "{{ .Values.agent.cloudability.pathToCloudabilitySecrets -}}/{{ .Values.agent.cloudability.customAzureBlobClientSecretFile }}"
             {{- end }}
             {{- else }}
-            - name: CLOUDABILITY_EMITTER_ENABLED
+            - name: CLOUDY_EMITTER_ENABLED
               value: "false"
-            {{- end }}            
+            {{- end }}
             - name: KUBECOST_EMITTER_ENABLED
             {{- if ((.Values.support).kubecostEmitterEnabled) }}
               {{- if eq .Values.support.kubecostEmitterEnabled "disabled" -}}

--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -148,6 +148,8 @@ spec:
               value: {{ (include "finops-agent.clusterId" .) | quote }}
             - name: CLOUDY_EMITTER_ENABLED
               value: "true"
+            - name: CLOUDABILITY_EMITTER_ENABLED
+              value: "true"
             - name: CLOUDABILITY_SCRATCH_DIR
               value: {{ .Values.agent.cloudability.localWorkingDir | quote }}
             - name: CLOUDABILITY_UPLOAD_REGION
@@ -226,6 +228,8 @@ spec:
             {{- end }}
             {{- else }}
             - name: CLOUDY_EMITTER_ENABLED
+              value: "false"
+            - name: CLOUDABILITY_EMITTER_ENABLED
               value: "false"
             {{- end }}
             - name: KUBECOST_EMITTER_ENABLED

--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -96,7 +96,6 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" .) | nindent 12 }}
           {{- end }}
           env:
-            # TODO
             {{- with .Values.agent.collectorDataSource }}
             {{- if .enabled }}
             - name: COLLECTOR_DATA_SOURCE_ENABLED
@@ -147,13 +146,12 @@ spec:
             {{- if .Values.agent.cloudability.enabled }}
             - name: CLOUDABILITY_CLUSTER_NAME
               value: {{ (include "finops-agent.clusterId" .) | quote }}
-            - name: CLOUDABILITY_EMITTER_ENABLED
+            - name: CLOUDY_EMITTER_ENABLED
               value: "true"
             - name: CLOUDABILITY_SCRATCH_DIR
               value: {{ .Values.agent.cloudability.localWorkingDir | quote }}
             - name: CLOUDABILITY_UPLOAD_REGION
               value: {{ .Values.agent.cloudability.uploadRegion | quote }}
-            {{- end }}
             {{- if .Values.agent.cloudability.httpsClientTimeout }}
             - name: CLOUDABILITY_HTTPS_CLIENT_TIMEOUT
               value: {{ .Values.agent.cloudability.httpsClientTimeout | quote}}
@@ -226,6 +224,10 @@ spec:
             - name: CLOUDABILITY_CUSTOM_AZURE_BLOB_CLIENT_SECRET_FILEPATH
               value: "{{ .Values.agent.cloudability.pathToCloudabilitySecrets -}}/{{ .Values.agent.cloudability.customAzureBlobClientSecretFile }}"
             {{- end }}
+            {{- else }}
+            - name: CLOUDABILITY_EMITTER_ENABLED
+              value: "false"
+            {{- end }}            
             - name: KUBECOST_EMITTER_ENABLED
             {{- if ((.Values.support).kubecostEmitterEnabled) }}
               {{- if eq .Values.support.kubecostEmitterEnabled "disabled" -}}


### PR DESCRIPTION
Fix logic and naming of cloudy env vars


## Testing:

```sh
helm upgrade ibm-finops-agent ~/git/finops-agent-chart/charts/finops-agent \
  -f helmValues-standard-new.yaml \
  --set agent.cloudability.enabled=false \
  --dry-run| ag 'CLOUDY|CLOUDABILITY' -A1
            - name: CLOUDY_EMITTER_ENABLED
              value: "false" 
```

enabled:

```sh
helm upgrade ibm-finops-agent ~/git/finops-agent-chart/charts/finops-agent \
  -f helmValues-standard-new.yaml \
  --set agent.cloudability.enabled=true \ 
  --dry-run| ag 'CLOUDY|CLOUDABILITY' -A1
---
            - name: CLOUDABILITY_CLUSTER_NAME
              value: "standard-cluster-1"
            - name: CLOUDY_EMITTER_ENABLED
              value: "true"
            - name: CLOUDABILITY_SCRATCH_DIR
              value: "/tmp"
            - name: CLOUDABILITY_UPLOAD_REGION
              value: "us-west-2"
            - name: CLOUDABILITY_HTTPS_CLIENT_TIMEOUT
              value: "60"
            - name: CLOUDABILITY_UPLOAD_RETRY_COUNT
              value: "5"
            - name: CLOUDABILITY_EMISSION_INTERVAL
              value: "3m"
            - name: CLOUDABILITY_KEY_ACCESS_FILEPATH
              value: "/opt/cloudability/CLOUDABILITY_KEY_ACCESS"
            - name: CLOUDABILITY_KEY_SECRET_FILEPATH
              value: "/opt/cloudability/CLOUDABILITY_KEY_SECRET"
            - name: CLOUDABILITY_ENV_ID_FILEPATH
              value: "/opt/cloudability/CLOUDABILITY_ENV_ID"
            - name: CLOUDABILITY_CUSTOM_AZURE_BLOB_CLIENT_SECRET_FILEPATH
              value: "/opt/cloudability/CLOUDABILITY_CUSTOM_AZURE_BLOB_CLIENT_SECRET"            
```

valid config:
<img width="705" height="324" alt="image" src="https://github.com/user-attachments/assets/142a4cd3-af0e-4b2d-bea0-431a6c6e2d60" />
