### PR TITLE
Bump agent image version and Chart version to v1.0.0

### DIFF
--- a/charts/finops-agent/Chart.yaml
+++ b/charts/finops-agent/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
   kubecost.com/version: 3.0.0-test.0
 apiVersion: v2
-appVersion: v1.0.0-rc.1
+appVersion: v1.0.0
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -28,4 +28,4 @@ maintainers:
 name: finops-agent
 sources:
 - https://github.com/kubecost/finops-agent-chart
-version: 1.0.0-rc.1
+version: 1.0.0

--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -117,7 +117,7 @@ useHelmHooks: true
 image:
   registry: icr.io
   repository: ibm-finops/agent
-  tag: v1.0.0-rc.1
+  tag: v1.0.0
   digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
```sh
docker pull icr.io/ibm-finops/agent:v1.0.0
Trying to pull icr.io/ibm-finops/agent:v1.0.0...
Getting image source signatures
Copying blob sha256:fa2ce77ae7963d21cb6adf616fd64bbd8512c14914581013812c34c513c954ae
Copying blob sha256:c3fdee3b91deb2d2256a5ba2a943df79a37717eda008b7c9923efb4efc66f249
Copying blob sha256:17093e23a0898de44df4e7f6f78fd9bd90452331fc4739c38d16a110a19af59e
Copying blob sha256:4e9c435eae66812b0832131e0f6e272f267b45cbb53c74e503f054b831b542be
Copying blob sha256:32f9ca5e5c54aa9b26064b19c38c940520796a38e08b0fc6836712e10c8b1d54
Copying blob sha256:9a4e728b4dbd07eee0ff5aee426ada8e5f72d613a16bf9cb8445c1cc226e37ec
Copying blob sha256:8d61394fe7fea940a0906c1a387f62643cc1424dfe52eef3e0d45c4b0f5cf69b
Copying blob sha256:e8b4a1b523b81b09c9bb6098aa86036f65eb77a376de571b5c256615000bbd0d
Copying blob sha256:b1b777d736051982bcdef376e6af8ba2faaadc48bf1e30568dd2b2d9d1e34b48
Copying config sha256:b8722fac5cd995f358c37ddd61e4d6c69fcfac38ece868c5a15c6dcdd2af397e
Writing manifest to image destination
b8722fac5cd995f358c37ddd61e4d6c69fcfac38ece868c5a15c6dcdd2af397e
```