### PR TITLE
KCM-4674 Fix federated storage config in deployment which kubecost is disabled

### DIFF
--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if include "finops-agent.kubecostEnabled" . }}
+        {{- if eq (include "finops-agent.kubecostEnabled" .) "true" }}
         checksum/federated-storage-config-secret: {{ include (print .Template.BasePath "/federated-storage-config-secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if or .Values.global.cspPricingApiKey.apiKey .Values.global.cspPricingApiKey.useDefaultApiKey }}
@@ -328,7 +328,7 @@ spec:
             - name: empty-dir
               mountPath: /var/configs
               subPath: configs-dir
-            {{- if include "finops-agent.kubecostEnabled" . }}
+            {{- if eq (include "finops-agent.kubecostEnabled" .) "true" }}
             - name: federated-storage-config
               mountPath: /var/configs/federated-store.yaml
               subPath: {{ include "finops-agent.federatedStorageFileName" . | trim }}
@@ -358,7 +358,7 @@ spec:
           emptyDir: {}
         - name: var-configs-empty-dir
           emptyDir: {}
-        {{- if include "finops-agent.kubecostEnabled" . }}
+        {{- if eq (include "finops-agent.kubecostEnabled" .) "true" }}
         - name: federated-storage-config
           secret:
             defaultMode: 420


### PR DESCRIPTION
Installed agent with these change:
```sh
helm upgrade --install finops ~/Desktop/Kubecost/finops-agent-chart/charts/finops-agent --set agent.cloudability.enabled=true --set agent.cloudability.uploadRegion=staging --set agent.cloudability.parseMetricData=false --set agent.cloudability.customS3UploadBucket='as-test-bucket' --set agent.cloudability.customS3UploadRegion='us-west-2' --set clusterId='test' -n cloudy-ishaan
```
Agent pod came into running state with no MountValue failed error:
<img width="1587" height="153" alt="Screenshot 2025-09-30 at 7 22 31 PM" src="https://github.com/user-attachments/assets/5bbfeec2-6ae2-4351-ad45-fe8229080931" />

Jira Ticket: https://apptio.atlassian.net/browse/KCM-4674