### PR TITLE
Bump agent image version and Chart version to v1.0.1

### DIFF
--- a/charts/finops-agent/Chart.yaml
+++ b/charts/finops-agent/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
   kubecost.com/version: 3.0.0-test.0
 apiVersion: v2
-appVersion: v1.0.0
+appVersion: v1.0.1
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -28,4 +28,4 @@ maintainers:
 name: finops-agent
 sources:
 - https://github.com/kubecost/finops-agent-chart
-version: 1.0.0
+version: 1.0.1

--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -117,7 +117,7 @@ useHelmHooks: true
 image:
   registry: icr.io
   repository: ibm-finops/agent
-  tag: v1.0.0
+  tag: v1.0.1
   digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
```sh
> docker pull icr.io/ibm-finops/agent:v1.0.1
Trying to pull icr.io/ibm-finops/agent:v1.0.1...
Getting image source signatures
Copying blob sha256:412f3b8ff34e49303c25b837ecf18f993a86ca0fc8bd8db904f132ac5f250303
Copying blob sha256:ee4697f8d40f2f1c472f337f5a8a6c8a6561b9d08240c588da98abfe53783d82
Copying blob sha256:c97fe1960b041878404dc71e95609d07a1d0ff12199b63e37feb424065c6f792
Copying blob sha256:96b3bc23a057b6ae8d531fa70f404445c15142b937ce0505892ee9ce55d088d6
Copying blob sha256:921bbe52765332647699c869f9523f270bcccddad114e320200b848a04991fbd
Copying blob sha256:4e9c435eae66812b0832131e0f6e272f267b45cbb53c74e503f054b831b542be
Copying blob sha256:7c8cc9de7a993129c6b62d701043e742ffe696661185383530cf0ebef4366a03
Copying blob sha256:ff847656df9d7f8650b8092c212b5410497ce337d61a1169316ea099148656e4
Copying blob sha256:61423f3ca928c1575f83280c4d3c262d6fe6ee8e13371ca6fa45ae9ae28e8340
Copying config sha256:fc39096cbd5b447ecaf5959039aca3526cd1883dbb0835e0c978eb109f918c72
Writing manifest to image destination
fc39096cbd5b447ecaf5959039aca3526cd1883dbb0835e0c978eb109f918c72
```