### PR TITLE
update default scrape interval to 60s

### DIFF
--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -205,7 +205,7 @@ logLevel: "info"
 agent:
   collectorDataSource:
     enabled: true
-    scrapeInterval: 60s
+    scrapeInterval: 60s  # If the agent diagnostics fails with node stat errors, consider increasing the interval or adding additional resources to the agent.
     networkPort: 3001
     retention10m: 6
     retention1h: 3

--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -205,7 +205,7 @@ logLevel: "info"
 agent:
   collectorDataSource:
     enabled: true
-    scrapeInterval: 30s
+    scrapeInterval: 60s
     networkPort: 3001
     retention10m: 6
     retention1h: 3

--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -205,7 +205,7 @@ logLevel: "info"
 agent:
   collectorDataSource:
     enabled: true
-    scrapeInterval: 60s  # If the agent diagnostics fails with node stat errors, consider increasing the interval or adding additional resources to the agent.
+    scrapeInterval: 60s
     networkPort: 3001
     retention10m: 6
     retention1h: 3


### PR DESCRIPTION
Setting default scrape to 60s to handle 99% of workloads.

This conrols the interval for scraping the k8s API for "nodes/stats/summary." In large or slow clusters, data can sometimes incur a delay. 
When the scrape takes longer than 30s the data is inconsistent, leading to inaccurate costs.