### PR TITLE
docs: document support.kubecostEmitterEnabled and support.opencostSourceEnabled flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ Both methods will deploy the same underlying container.
 
 ## Installing the FinOps Agent
 
+
+
+## Advanced Configuration
+
+### Disabling Kubecost Data Collection
+
+By default, the FinOps Agent automatically enables Kubecost data collection when `global.federatedStorage` is configured. To disable Kubecost while keeping the agent running (e.g., for Cloudability-only deployments), use the following advanced override flags:
+
+```yaml
+support:
+  kubecostEmitterEnabled: "disabled"
+  opencostSourceEnabled: "disabled"
+```
+
+**Note:** These are advanced override flags. Setting them to any value other than `"disabled"` will force-enable the respective emitter. Omitting these parameters allows the agent to automatically determine enablement based on `global.federatedStorage` configuration.
+
+**Use cases for these flags:**
+- Cloudability-only deployments
+- Troubleshooting data pipeline issues
+- Migration scenarios requiring gradual enablement/disablement
+- Cost optimization when Kubecost data is not needed
+
 Follow the instructions in the chart's [README](charts/finops-agent/README.md) to install the FinOps Agent using this Helm chart.
 
 ## License

--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -274,6 +274,20 @@ agent:
     spotLabel: ""
     spotLabelValue: ""
 
+
+## @section Support parameters (Advanced)
+## These are advanced override flags for specific use cases.
+## In most cases, you should not need to set these values.
+## The agent automatically enables Kubecost data collection when global.federatedStorage is configured.
+## Use these flags to override that behavior.
+
+## @param support.kubecostEmitterEnabled Override automatic Kubecost enablement. Set to "disabled" to force disable Kubecost data collection even when global.federatedStorage is configured. Any other value (or omitting this parameter) will enable it.
+## @param support.opencostSourceEnabled Override automatic OpenCost source enablement. Set to "disabled" to force disable OpenCost data source even when global.federatedStorage is configured. Any other value (or omitting this parameter) will enable it.
+##
+# support:
+#   kubecostEmitterEnabled: "disabled"
+#   opencostSourceEnabled: "disabled"
+
 ## @param command Override default container command (useful when using custom images)
 ##
 command: []


### PR DESCRIPTION
Fixes #94

## Summary
Added documentation for two previously undocumented support flags that allow users to override automatic Kubecost enablement.

## Changes
- Added `@section Support parameters (Advanced)` in `charts/finops-agent/values.yaml` with detailed parameter documentation
- Added `Advanced Configuration` section to `README.md` explaining use cases and examples
- Documented that setting to `"disabled"` forces disable, any other value enables

## Flags Documented
- `support.kubecostEmitterEnabled` - Override automatic Kubecost emitter enablement
- `support.opencostSourceEnabled` - Override automatic OpenCost source enablement

## Use Cases
These flags are essential for:
- Cloudability-only deployments
- Troubleshooting data pipeline issues
- Migration scenarios requiring gradual enablement/disablement
- Cost optimization when Kubecost data is not needed

## Testing
- [x] Documentation added to values.yaml follows existing @param format
- [x] README.md updated with clear examples
- [x] Commit message follows conventional commits format