### PR TITLE
changes to acommodate metrics agent - finops pr 207

### DIFF
--- a/charts/finops-agent/templates/cloudability-secret.yaml
+++ b/charts/finops-agent/templates/cloudability-secret.yaml
@@ -21,6 +21,9 @@ metadata:
   {{- end }}
 type: Opaque
 data:
+  {{- if .Values.agent.cloudability.apiKeyFile }}
+  {{ .Values.agent.cloudability.apiKeyFile }}: {{ .Values.agent.cloudability.secret.cloudabilityApiKey | b64enc | quote }}
+  {{- end }}
   CLOUDABILITY_KEY_ACCESS: {{ .Values.agent.cloudability.secret.cloudabilityAccessKey | b64enc | quote }}
   CLOUDABILITY_KEY_SECRET: {{ .Values.agent.cloudability.secret.cloudabilitySecretKey | b64enc | quote }}
   CLOUDABILITY_ENV_ID: {{ .Values.agent.cloudability.secret.cloudabilityEnvId | b64enc | quote }}

--- a/charts/finops-agent/templates/cloudability-secret.yaml
+++ b/charts/finops-agent/templates/cloudability-secret.yaml
@@ -21,8 +21,8 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if .Values.agent.cloudability.apiKeyFile }}
-  {{ .Values.agent.cloudability.apiKeyFile }}: {{ .Values.agent.cloudability.secret.cloudabilityApiKey | b64enc | quote }}
+  {{- if .Values.agent.cloudability.secret.cloudabilityApiKey }}
+  CLOUDABILITY_API_KEY: {{ .Values.agent.cloudability.secret.cloudabilityApiKey | b64enc | quote }}
   {{- end }}
   CLOUDABILITY_KEY_ACCESS: {{ .Values.agent.cloudability.secret.cloudabilityAccessKey | b64enc | quote }}
   CLOUDABILITY_KEY_SECRET: {{ .Values.agent.cloudability.secret.cloudabilitySecretKey | b64enc | quote }}

--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -269,6 +269,10 @@ spec:
             - name: CLOUDABILITY_CUSTOM_AZURE_BLOB_CLIENT_ID
               value: {{ .Values.agent.cloudability.customAzureClientID | quote }}
             {{- end }}
+            {{- if .Values.agent.cloudability.apiKeyFile }}
+            - name: CLOUDABILITY_API_KEY_FILEPATH
+              value: "{{ .Values.agent.cloudability.pathToCloudabilitySecrets -}}/{{ .Values.agent.cloudability.apiKeyFile }}"
+            {{- end }}
             {{- if .Values.agent.cloudability.keyAccessFile }}
             - name: CLOUDABILITY_KEY_ACCESS_FILEPATH
               value: "{{ .Values.agent.cloudability.pathToCloudabilitySecrets -}}/{{ .Values.agent.cloudability.keyAccessFile }}"

--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -175,6 +175,7 @@ logLevel: "info"
 ## @param agent.exporter.emissionInterval A duration string of how often the core agent exporter will emit new data snapshots to the enabled emitters.
 ## @param agent.cloudability.enabled Enable the cloudability data source
 ## @param agent.cloudability.pathToCloudabilitySecrets the path to the location on the filesystem the cloudability secrets are stored
+## @param agent.cloudability.apiKeyFile the name of the file containing the Containers Insights API key (legacy metrics-agent upload path)
 ## @param agent.cloudability.keyAccessFile the name of the keyAccessFile
 ## @param agent.cloudability.keySecretFile the name of the keySecretFile
 ## @param agent.cloudability.envIDFile the name of the envIDFile
@@ -197,6 +198,7 @@ logLevel: "info"
 ## @param agent.cloudability.customAzureBlobClientSecretFile the name of the customAzureBlobClientSecretFile
 ## @param agent.cloudability.secret.existingSecret The name of an existing secret to use for the cloudability data source. Note, you cannot set both `create` and `existingSecret`.
 ## @param agent.cloudability.secret.create Create a secret for the cloudability data source. cannot be used with existingSecret
+## @param agent.cloudability.secret.cloudabilityApiKey The Containers Insights API key for metrics-collector upload (legacy metrics-agent path)
 ## @param agent.cloudability.secret.cloudabilityAccessKey The cloudability access key for the cloudability data source
 ## @param agent.cloudability.secret.cloudabilitySecretKey The cloudability secret key for the cloudability data source
 ## @param agent.cloudability.secret.cloudabilityEnvId The cloudability env id for the cloudability data source
@@ -224,6 +226,7 @@ agent:
     ## Cloudability requires an API key to send data to the cloudability platform
     enabled: false
     pathToCloudabilitySecrets: "/opt/cloudability"
+    apiKeyFile: "CLOUDABILITY_API_KEY"
     keyAccessFile: "CLOUDABILITY_KEY_ACCESS"
     keySecretFile: "CLOUDABILITY_KEY_SECRET"
     envIDFile: "CLOUDABILITY_ENV_ID"
@@ -248,6 +251,7 @@ agent:
     secret:
       create: true
       existingSecret: ""
+      cloudabilityApiKey: ""
       cloudabilityAccessKey: ""
       cloudabilitySecretKey: ""
       cloudabilityEnvId: ""

--- a/examples/cloudability/helmValues-cloudability-gcp.yaml
+++ b/examples/cloudability/helmValues-cloudability-gcp.yaml
@@ -6,6 +6,7 @@ agent:
   cloudability:
     enabled: true
     secret:
+      cloudabilityApiKey: ""
       cloudabilityAccessKey: ""
       cloudabilityEnvId: ""
       cloudabilitySecretKey: ""


### PR DESCRIPTION
Ticket - https://apptio.atlassian.net/browse/KCM-5858
finops pr - https://github.com/kubecost/ibm-finops-agent/pull/207

Adds Helm support for the legacy Containers Insights API key upload path: `agent.cloudability.secret.cloudabilityApiKey` and `apiKeyFile` mount `CLOUDABILITY_API_KEY` at /opt/cloudability/ and set `CLOUDABILITY_API_KEY_FILEPATH` on the agent pod. 

Open questions (this is my first chart change): 
 - How should I think about chart changes in terms of tying it to a release? 
 - Kubecost subchart — Does the main `kubecost` chart need matching `finopsagent` values/docs when this chart releases?