### PR TITLE
Update publish action

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -93,20 +93,12 @@ jobs:
           git commit -m "Update chart index for ${{ github.ref_name }}"
           git push origin gh-pages
 
-      - name: Checkout github-actions
-        uses: actions/checkout@v6
-        with:
-          repository: kubecost/github-actions
-          path: github-actions
-          token: ${{ secrets.ACTIONS_PAT }}
-
-      - name: Create Release
-        uses: ./github-actions/action-gh-release
-        with:
-          files: .cr-release-packages/*.tgz
-          generate_release_notes: true
-          draft: false
-          prerelease: false
+      - name: Update Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}
+        run: |
+          gh release upload "${{ github.ref_name }}" .cr-release-packages/*.tgz \
+            --repo "${{ github.repository }}"
 
       - name: Notify Release
         uses: slackapi/slack-github-action@v3


### PR DESCRIPTION
Underlying release action was removed from here: https://github.com/kubecost/github-actions/pull/441

Needs a way to upload final zip to existing release