### PR TITLE
Fix release upload, by first creating a release

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -93,12 +93,24 @@ jobs:
           git commit -m "Update chart index for ${{ github.ref_name }}"
           git push origin gh-pages
 
-      - name: Update Release
+      - name: Create or Update Release
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}
         run: |
-          gh release upload "${{ github.ref_name }}" .cr-release-packages/*.tgz \
-            --repo "${{ github.repository }}"
+          # Check if release exists
+          if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release ${{ github.ref_name }} exists, uploading chart package..."
+            gh release upload "${{ github.ref_name }}" .cr-release-packages/*.tgz \
+              --repo "${{ github.repository }}" \
+              --clobber  # Replace existing assets if present (enables idempotency)
+          else
+            echo "Creating release ${{ github.ref_name }} with chart package..."
+            gh release create "${{ github.ref_name }}" \
+              .cr-release-packages/*.tgz \
+              --repo "${{ github.repository }}" \
+              --title "${{ github.ref_name }}" \
+              --generate-notes
+          fi
 
       - name: Notify Release
         uses: slackapi/slack-github-action@v3


### PR DESCRIPTION
Fixes the following workflow failure [here](https://github.com/kubecost/finops-agent-chart/actions/runs/29870908666/job/88770515302). Not yet tested. I think this is a low risk PR, which can be tested on the next patch release. For now, I am manually creating the Github Release.

```log
Run gh release upload "v1.0.22" .cr-release-packages/*.tgz \
  gh release upload "v1.0.22" .cr-release-packages/*.tgz \
    --repo "kubecost/finops-agent-chart"
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
release not found
Error: Process completed with exit code 1.
```

Related to https://github.com/kubecost/finops-agent-chart/pull/110