### PR TITLE
agent storage retention and diagnostic cleanup interval

### DIFF
--- a/charts/finops-agent/templates/deployment.yaml
+++ b/charts/finops-agent/templates/deployment.yaml
@@ -210,6 +210,16 @@ spec:
             - name: DIAGNOSTICS_EXPORT_INTERVAL
               value: {{ .Values.agent.exportIntervals.diagnostics | quote }}
             {{- end }}
+            {{- with .Values.agent.storageRetention }}
+            - name: HEARTBEAT_STORAGE_RETENTION
+              value: {{ .heartbeat | quote }}
+            - name: DIAGNOSTICS_STORAGE_RETENTION
+              value: {{ .diagnostics | quote }}
+            {{- end }}
+            {{- if .Values.agent.storageCleanupInterval }}
+            - name: STORAGE_CLEANUP_INTERVAL
+              value: {{ .Values.agent.storageCleanupInterval | quote }}
+            {{- end }}
 
             {{- if .Values.agent.cloudability.enabled }}
             - name: CLOUDABILITY_CLUSTER_NAME

--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -174,6 +174,9 @@ logLevel: "info"
 ## @param agent.exportIntervals.networkInsight A duration string of how often network insight data is exported.
 ## @param agent.exportIntervals.heartbeat A duration string of how often heartbeat data is exported.
 ## @param agent.exportIntervals.diagnostics A duration string of how often diagnostics data is exported.
+## @param agent.storageRetention.heartbeat How long heartbeat objects are retained in federated storage before cleanup. Set to `0` or `0s` to disable.
+## @param agent.storageRetention.diagnostics How long diagnostics objects are retained in federated storage before cleanup. Set to `0` or `0s` to disable.
+## @param agent.storageCleanupInterval How often the agent scans federated storage for expired heartbeat/diagnostics objects.
 ## @param agent.nodes.backgroundStatsCollector Allows for node stats to be collected asynchronously to allow for greater scale
 ## @param agent.nodes.concurrentPollers The number of concurrent node pollers used when collecting node stats. When empty, the agent's built-in default is used.
 ## @param agent.exporter.emissionInterval A duration string of how often the core agent exporter will emit new data snapshots to the enabled emitters.
@@ -226,6 +229,13 @@ agent:
     networkInsight: 10m
     heartbeat: 5m
     diagnostics: 10m
+  # How long heartbeat/diagnostics objects are kept in the federated storage
+  # bucket before this agent deletes them. These are source objects under
+  # finops-agent/<cluster>/{heartbeat,diagnostics}/, not aggregator DB retention.
+  storageRetention:
+    heartbeat: 7d
+    diagnostics: 7d
+  storageCleanupInterval: 1h
   exporter:
     emissionInterval: 1m
     exportLegacyDataModels: true


### PR DESCRIPTION
 - Expose agent storage retention and cleanup interval via Helm
 - Defaults: agent.storageRetention.heartbeat/diagnostics: 7d, agent.storageCleanupInterval: 1h
 - Set retention to 0/0s to disable

Notes
 - Requires the matching ibm-finops-agent change.
 - Same time-based cleanup caveats as the agent PR. https://github.com/kubecost/ibm-finops-agent/pull/211
 - 
Closes
 - https://apptio.atlassian.net/browse/KCM-5391