### PR TITLE
Bump to v1.0.25 release

### DIFF
--- a/charts/finops-agent/Chart.yaml
+++ b/charts/finops-agent/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
   kubecost.com/version: 3.0.0-test.0
 apiVersion: v2
-appVersion: v1.0.24
+appVersion: v1.0.25
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
@@ -31,4 +31,4 @@ maintainers:
 name: finops-agent
 sources:
   - https://github.com/kubecost/finops-agent-chart
-version: 1.0.24
+version: 1.0.25

--- a/charts/finops-agent/values.yaml
+++ b/charts/finops-agent/values.yaml
@@ -149,7 +149,7 @@ useHelmHooks: true
 image:
   registry: icr.io
   repository: ibm-finops/agent
-  tag: v1.0.24
+  tag: v1.0.25
   digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
```sh
$ podman pull icr.io/ibm-finops/agent:v1.0.25
Trying to pull icr.io/ibm-finops/agent:v1.0.25...
Getting image source signatures
Copying blob sha256:05fd479fcf0a1163ba36c2d308b8460fb80ec1b89b2644e450ba919e387e0361
Copying blob sha256:26939cbd0bfb4a559349449019ac42b47dc6bd4dd3e34d174313326f06f3a0f2
Copying blob sha256:b6282f7e026511006101bde355f8eded51e84ec4bcd1272f4ae3cb1d9a6c6ffa
Copying blob sha256:6dcb6677ca7d0dd70e60666c35418aa590d0d644e2e9fcb4e891d99cb4d9cc79
Copying blob sha256:db3227b3cddb9af3156248ee4600e81d60158199b35524c91b91d63556dc1bee
Copying blob sha256:f8029eac90385f0b3999efd40cb19b153b47b6202be8e37c490e62b96a56c603
Copying blob sha256:e022633f7c85df986e5e139e3d5c303c2b10cc22074594158f3ccd3c38bbb0dc
Copying blob sha256:7f0efecf2588155c7829746240bca84baf58d7341032bc5aeed079f6e284c79b
Copying blob sha256:915fa0aac5ddcec0e19205f09fac86d634e578810a1ce3472c3db3433d31381c
Copying blob sha256:ead6effd9991d50c17d3700baadccd5e28f005c8fd0bb32fed6a6350fd99004c
Copying config sha256:547e691cc563ee0ac5a9ae84d233a5037e088c004b7502a8b4ca693841eaaacc
Writing manifest to image destination
547e691cc563ee0ac5a9ae84d233a5037e088c004b7502a8b4ca693841eaaacc
```