### PR TITLE
Replace PAT with App Token in publish-chart workflow

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -3,7 +3,7 @@ name: Publish Helm Chart
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   publish:
@@ -12,6 +12,13 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate app token
+        id: generate-app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.KC_ACTIONS_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.KC_ACTIONS_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -95,7 +102,7 @@ jobs:
 
       - name: Create or Update Release
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}
+          GH_TOKEN: ${{ steps.generate-app-token.outputs.token }}
         run: |
           # Check if release exists
           if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then


### PR DESCRIPTION
As titled. Similar to https://github.com/kubecost/ibm-finops-agent/pull/227 which successfully resolved the issue.

Intended to resolve the following error

```
Run # Check if release exists
  # Check if release exists
  if gh release view "v1.0.25" --repo "kubecost/finops-agent-chart" >/dev/null 2>&1; then
    echo "Release v1.0.25 exists, uploading chart package..."
    gh release upload "v1.0.25" .cr-release-packages/*.tgz \
      --repo "kubecost/finops-agent-chart" \
      --clobber  # Replace existing assets if present (enables idempotency)
  else
    echo "Creating release v1.0.25 with chart package..."
    gh release create "v1.0.25" \
      .cr-release-packages/*.tgz \
      --repo "kubecost/finops-agent-chart" \
      --title "v1.0.25" \
      --generate-notes
  fi
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
Creating release v1.0.25 with chart package...
HTTP 403: The 'kubecost' organization forbids access via a personal access tokens (classic) if the token's lifetime is greater than 90 days. Please adjust your token's lifetime at the following URL: https://github.com/settings/tokens/4941612381 (https://api.github.com/repos/kubecost/finops-agent-chart/releases)
Error: Process completed with exit code 1.
```